### PR TITLE
Ajustement de l'aggréation pour la Pagination et renforcement des paramètres pour le slowdown middleware

### DIFF
--- a/.env.exemple
+++ b/.env.exemple
@@ -5,8 +5,9 @@ ENVIRONNEMENT='development'#development, staging, production
 LOG_PERFORMANCE=false
 LOG_TO_FILE=true
 DEBUG_SLOW_CONNEXION=false
+DEBUG_SLOW_DURATION=3000
 
-BASEURL="http://localhost:8000/"
+BASEURL="http://localhost:8000"
 SERVER_PATH="/api"
 APP_PATH="/api"
 FRONTEND_APP_URL="http://localhost:3000"
@@ -80,7 +81,7 @@ USERS_DB_MIGRATION_USER='appBdUser'
 USERS_DB_MIGRATION_PASSWORD='appBdUserPw'
 
 ## List of URL with a space in between cors.
-CORS_ALLOWED_ORIGINS='http://localhost:3000'
+CORS_ALLOWED_ORIGINS='http://localhost:3000 http://localhost:8000'
 
 QUERY_DEFAULT_LIMIT=50
 QUERY_DEFAULT_SKIP=0

--- a/src/Database/Aggregation/PaginationAggregation.ts
+++ b/src/Database/Aggregation/PaginationAggregation.ts
@@ -8,6 +8,35 @@ interface AggregationResultContract {
 }
 
 /**
+ * Safe walling of the last page if the request page / skip > than the total size of the aggregate.
+ * @param requestedPage
+ * @param limit
+ * @param totalDocuments
+ */
+function safeSkip(requestedPage: number, limit: number, totalDocuments: number): number {
+    // Ensure minimum values
+    const page = Math.max(1, Math.floor(requestedPage));
+    const pageSize = Math.max(1, Math.floor(limit));
+
+    // Calculate total pages
+    const totalPages = Math.ceil(totalDocuments / pageSize);
+
+    // If no documents, return 0
+    if (totalDocuments <= 0) {
+        return 0;
+    }
+
+    // Clamp the page to valid range (1 to totalPages)
+    const safePage = Math.min(page, totalPages);
+
+    // Calculate skip (page is 1-indexed)
+    const skip = (safePage - 1) * pageSize;
+
+    return (safePage - 1) * pageSize;
+}
+
+
+/**
  * Prevent over pagination aggregation by checking if the search have the total pages asked for.
  * It does force default value of page size. This must be walled upstream.
  * @param model {mongoose.Model<any>}
@@ -27,17 +56,19 @@ async function paginationAggregation(model:mongoose.Model<any>, aggregationPipel
         const totalDocuments = countResult ? countResult.totalDocuments : 0;
 
 
-
         if (totalDocuments === 0) return countResult;//no result
 
-        const maxPageNumber = Math.round(totalDocuments / limit);//removed floor because we need the last part.
-
+        const maxPageNumber = Math.ceil(totalDocuments / limit);//removed floor because we need the last part.
+        const currentPage = Math.floor(skip / limit);
         // Calculate expected page length
-        const firstDocumentOnPageIndex = Number(skip) * Number(limit);
-        const nextPageLength = Math.min(limit, totalDocuments - skip);
+        const lastPageSkipNumber = totalDocuments - (totalDocuments - skip);//weird, mais c'est ce que je pense qui est ok.
+        const firstDocumentOnPageIndex = Number(currentPage) * Number(limit);
+        const nextPageLength = Math.min(limit, totalDocuments - firstDocumentOnPageIndex);//check if the current skip is in the last page, and adjust to it.
         const modificatedParameters:any = {};
 
-        console.log("paginationAggregation", "count", countResult, "total", totalDocuments, "skip", skip, "pageSize", limit, "sort", sort, "nextPageLength", nextPageLength, "firstDocumentOnPageIndex", firstDocumentOnPageIndex);
+        const nextSkip = safeSkip(currentPage+1, limit, totalDocuments);//Math.min(firstDocumentOnPageIndex, lastPageSkipNumber);
+
+        console.log("paginationAggregation", "count", countResult, "total", totalDocuments, "currentPage (start at 0)", currentPage, "maxPageNumber", maxPageNumber, "skip", skip, "nextSkip", nextSkip, "pageSize", limit, "sort", sort, "nextPageLength", nextPageLength, "firstDocumentOnPageIndex", firstDocumentOnPageIndex);
 
         //check if the skip is within the max documents of the query.
         /*if (firstDocumentOnPageIndex >= totalDocuments && firstDocumentOnPageIndex > 0) {
@@ -54,7 +85,7 @@ async function paginationAggregation(model:mongoose.Model<any>, aggregationPipel
                 $facet: {
                     paginatedResults: [
                         { $sort: { updatedAt: sort } },
-                        { $skip: skip },
+                        { $skip: nextSkip },
                         { $limit: limit }
                     ],
                     meta: [

--- a/src/Database/Aggregation/PaginationAggregation.ts
+++ b/src/Database/Aggregation/PaginationAggregation.ts
@@ -8,30 +8,23 @@ interface AggregationResultContract {
 }
 
 /**
- * Safe walling of the last page if the request page / skip > than the total size of the aggregate.
- * @param requestedPage
- * @param limit
- * @param totalDocuments
+ * Safe wall-ing of the last page if the request page / skip > than the total size of the aggregate.
+ * @param requestedPage {number} the target page requested by
+ * @param limit {number} the current limit from what we are checking the max skip.
+ * @param totalDocuments {number} total length of the current query.
  */
 function safeSkip(requestedPage: number, limit: number, totalDocuments: number): number {
-    // Ensure minimum values
+
     const page = Math.max(1, Math.floor(requestedPage));
     const pageSize = Math.max(1, Math.floor(limit));
-
-    // Calculate total pages
     const totalPages = Math.ceil(totalDocuments / pageSize);
 
-    // If no documents, return 0
     if (totalDocuments <= 0) {
         return 0;
     }
 
     // Clamp the page to valid range (1 to totalPages)
     const safePage = Math.min(page, totalPages);
-
-    // Calculate skip (page is 1-indexed)
-    const skip = (safePage - 1) * pageSize;
-
     return (safePage - 1) * pageSize;
 }
 

--- a/src/Server/Middlewares/SlowDownMiddleware.ts
+++ b/src/Server/Middlewares/SlowDownMiddleware.ts
@@ -46,32 +46,3 @@ const SlowDownMiddleware = (options = {} as SlowDownOptions ) => {
 
 export default SlowDownMiddleware;
 export {SlowDownOptions};
-
-// Usage example:
-/*
-const express = require('express');
-const slowDown = require('./slowDown');
-
-const app = express();
-
-// Basic usage - adds 1 second delay to all requests
-app.use(slowDown());
-
-// Advanced usage with options
-app.use(slowDown({
-  delay: 2000,
-  verbose: true,
-  shouldDelay: (req) => {
-    // Only delay API requests
-    return req.path.startsWith('/api');
-  }
-}));
-
-// Can also be applied to specific routes
-app.get('/api/slow-endpoint',
-  slowDown({ delay: 3000 }),
-  (req, res) => {
-    res.json({ message: 'This response was delayed' });
-  }
-);
-*/

--- a/src/api.ts
+++ b/src/api.ts
@@ -95,7 +95,10 @@ export default class Api {
         // parse application/json
         this.express.use(express.json());
         if (this._config.environnement === 'development' && this._slowDown) {
-            this.express.use(SlowDownMiddleware());
+            this.express.use(SlowDownMiddleware({
+                delay: this._config.debugSlowDuration,
+                verbose: true
+            }));
         }
 
         this.templateBasePath = `${this._config.appPath}/views`;

--- a/src/config.ts
+++ b/src/config.ts
@@ -16,7 +16,8 @@ const getApiConfig = () => {
         isStaging: process.env.ENVIRONNEMENT === 'staging',
         isDevelopment: process.env.ENVIRONNEMENT === 'development',
 
-        debugSlowConnection: process.env.DEBUG_SLOW_CONNECTION || false,
+        debugSlowConnection: process.env.DEBUG_SLOW_CONNEXION || false,
+        debugSlowDuration: process.env.DEBUG_SLOW_DURATION || 1000,
 
         // Dev configuration.
         mongooseDebug: process.env.ENVIRONNEMENT === 'development' && process.env.MONGOOSE_DEBUG === 'true' ,

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -3,7 +3,7 @@ import EmbedTaxonomiesMetas from "@src/Schedule/Jobs/EmbedTaxonomiesMetas";
 import EmailNotification from "@src/Notifications/EmailNotification";
 import {StatusCodes} from "http-status-codes";
 import {EmailConfirmationContent} from "@src/Templates/Contents/EmailConfirmationContent";
-import config from "@src/config";
+import config, {getApiConfig} from "@src/config";
 import PublicTemplate from "@src/Templates/PublicTemplate";
 import {getTemplateBaseData} from "@src/Templates/Emails/EmailData";
 import DefaultEmailTheme from "@src/Templates/Themes/DefaultEmailTheme";
@@ -13,11 +13,13 @@ const ApiRouter = express.Router();
 
 // Would this print the doc or not ?
 ApiRouter.get("/", async (req, res) => {
+    const updatedConfig = getApiConfig();
     const baseData = getTemplateBaseData();
-    const index = new PublicTemplate();//tempalte have already a default in the EmailContent.Prepare.
-    const title:string = `${config.appName} (version ${config.version})`;
-    let body:string = config.environnement === 'development' ? `écoute sur le port: ${config.port}<br />` : '';
-    body += baseData.api.description;
+    const index = new PublicTemplate();//template have already a default in the EmailContent.Prepare.
+    const title:string = `${updatedConfig.appName} (version ${updatedConfig.version})`;
+    let body:string = updatedConfig.environnement === 'development' ? `<p>écoute sur le port: ${updatedConfig.port}<br /></p>` : '';
+    body += `<p>${baseData.api.description}</p>`;
+    body += updatedConfig.environnement === 'development' ? `<p>Slow Down Middleware est <strong>${updatedConfig.debugSlowConnection ? 'activé' : 'désactivé'}</strong> et ralenti avec ${updatedConfig.debugSlowDuration}ms</p>` : "";
     res.set('Content-Type', 'text/html');
     LogHelper.info("Rendering index", baseData);
     return res.status(StatusCodes.OK).send(await index.render({
@@ -29,7 +31,7 @@ ApiRouter.get("/", async (req, res) => {
             meta: {
                 title: `${title}`,
                 description: `${body}`,
-                author: `${config.appName}`
+                author: `${updatedConfig.appName}`
             }
         }
     }));
@@ -47,7 +49,7 @@ ApiRouter.get('/quarante-deux',async (req, res) => {
     const baseData = getTemplateBaseData();
     const index42 = new PublicTemplate("quarante-deux");//tempalte have already a default in the EmailContent.Prepare.
     const title:string = `The Answer to the Ultimate Question of Life, the Universe, and Everything`;
-    let body:string = '';
+    const body:string = '';
     res.set('Content-Type', 'text/html');
     return res.status(StatusCodes.OK).send(await index42.render({
         context: {
@@ -81,44 +83,47 @@ ApiRouter.get('/42',async (req, res) => {
 });
 
 ApiRouter.get("/embed-taxonomies-metas", async (req, res) => {
-    res.send(`Embeding taxonomies metas`);
+    res.send(`Manually embeding taxonomies metas`);
     await EmbedTaxonomiesMetas();
 });
 
-ApiRouter.get("/test-email", async (req, res) => {
-    const testNotification:EmailNotification = new EmailNotification(
-        {
-            recipient:"marcandre.martin@gmail.com",
-            subject: "Mam, Confirmez ce courriel pour votre compte sur avnu.ca"
-        },
-        EmailConfirmationContent("mam", "http://localhost:8000/verify-account/ef2254979c0f073a1f75bf03a404fa3b2547cb9bc858c54f06f5571a68a892156602c101370f08ef6d0cd15c3004663dbee15fdb052107da5e5bc30cf16ce4a133c250cda6f1478e25c7614326706af37d5fbec12f545040621cdfdd548d32c984116652d1aab97f7f6a734c19c125f2d610e1528d8529822c1a73912e53e389")
-    );
-    //testNotification.send();
-    res.set('Content-Type', 'text/html');
-    return res.status(StatusCodes.OK).send(await testNotification.preview());
-});
+if (config.environnement === 'development') {
+    ApiRouter.get("/test-email", async (req, res) => {
+        const testNotification:EmailNotification = new EmailNotification(
+            {
+                recipient:"marcandre.martin@gmail.com",
+                subject: "Mam, Confirmez ce courriel pour votre compte sur avnu.ca"
+            },
+            EmailConfirmationContent("mam", "http://localhost:8000/verify-account/ef2254979c0f073a1f75bf03a404fa3b2547cb9bc858c54f06f5571a68a892156602c101370f08ef6d0cd15c3004663dbee15fdb052107da5e5bc30cf16ce4a133c250cda6f1478e25c7614326706af37d5fbec12f545040621cdfdd548d32c984116652d1aab97f7f6a734c19c125f2d610e1528d8529822c1a73912e53e389")
+        );
+        //testNotification.send();
+        res.set('Content-Type', 'text/html');
+        return res.status(StatusCodes.OK).send(await testNotification.preview());
+    });
 
-ApiRouter.get("/sync-db", async (req, res) => {
+    ApiRouter.get("/sync-db", async (req, res) => {
 
-    const index = new PublicTemplate("default");//tempalte have already a default in the EmailContent.Prepare.
-    const title:string = `Syncing db`;
-    let body:string = 'Sync prod into staging data only.';
+        const index = new PublicTemplate("default");//tempalte have already a default in the EmailContent.Prepare.
+        const title:string = `Syncing db`;
+        let body:string = 'Sync prod into staging data only.';
 
-    res.set('Content-Type', 'text/html');
-    const baseData = getTemplateBaseData();
-    return res.status(StatusCodes.OK).send(await index.render({
-        context: {
-            ...baseData,//basic app and api default string and links
-            ...DefaultEmailTheme,//basic theme for colors and sizes.
-            title: `${title}`,
-            body: `${body}`,
-            meta: {
+        res.set('Content-Type', 'text/html');
+        const baseData = getTemplateBaseData();
+        return res.status(StatusCodes.OK).send(await index.render({
+            context: {
+                ...baseData,//basic app and api default string and links
+                ...DefaultEmailTheme,//basic theme for colors and sizes.
                 title: `${title}`,
-                description: `${body}`,
-                author: `${config.appName}`
+                body: `${body}`,
+                meta: {
+                    title: `${title}`,
+                    description: `${body}`,
+                    author: `${config.appName}`
+                }
             }
-        }
-    }));
-});
+        }));
+    });
+}
+
 
 export {ApiRouter};


### PR DESCRIPTION
L'API a un safeguard si on demande une page trop grande pour l'aggréga.
Le slowdown middleware se fit maintenant à l'environnement pour être actif ou non. J'ai mis un paramètre pour la duré du slowndown. On peut aussi le paramétrer dans le fichier api.ts pour faire des tests plus lent, etc.