### PR TITLE
Ajustements du sanitizer HTML pour accepter les options de l'éditeur de texte enrichi

### DIFF
--- a/src/Security/Sanitizers/HtmlSanitizer.ts
+++ b/src/Security/Sanitizers/HtmlSanitizer.ts
@@ -21,6 +21,7 @@ export class HtmlSanitizer {
                 "h5",
                 "h6",
                 "blockquote",
+                "del",
                 "dl",
                 "dt",
                 "figcaption",
@@ -70,6 +71,8 @@ export class HtmlSanitizer {
             ],
             disallowedTagsMode: "discard",
             allowedAttributes: {
+                p: ["class"],
+                span: ["style"],
                 a: ["href", "name", "target"],
                 // We don't currently allow img itself by default, but
                 // these attributes would make sense if we did.


### PR DESCRIPTION
Balise `<del>` pour le texte barré, attribut `class` des paragraphes pour le texte centré et aligné à droite, et attribut `style` des `<span>` pour le texte en couleurs. 